### PR TITLE
Sku RefId not persisted with quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Hide logo when url is `/`
+- Add sku refId when saving the quote
+
 ## [1.2.1] - 2020-11-26
 
 ### Fixed

--- a/react/QuoteCreate.tsx
+++ b/react/QuoteCreate.tsx
@@ -207,7 +207,7 @@ const QuoteCreate: StorefrontFunctionComponent<WrappedComponentProps & any> = ({
             return {
               name: item.name,
               skuName: item.skuName,
-              refId: item.productRefId,
+              refId: item.refId,
               id: item.id,
               productId: item.productId,
               imageUrl: item.imageUrl,

--- a/react/QuoteView.tsx
+++ b/react/QuoteView.tsx
@@ -418,7 +418,7 @@ const QuoteCreate: StorefrontFunctionComponent<WrappedComponentProps & any> = ({
             <div
               className={`flex flex-column w-100 ${handles.containerFields}`}
             >
-              {!!logo && logo !== '' && (
+              {!!logo && logo !== '/' && (
                 <div className="mb5">
                   <img
                     src={logo}

--- a/react/QuoteView.tsx
+++ b/react/QuoteView.tsx
@@ -281,7 +281,7 @@ const QuoteCreate: StorefrontFunctionComponent<WrappedComponentProps & any> = ({
         title: translateMessage({
           id: 'store/orderquote.cartList.label.sku',
         }),
-        width: 100,
+        width: 150,
       },
       skuName: {
         title: translateMessage({
@@ -418,7 +418,7 @@ const QuoteCreate: StorefrontFunctionComponent<WrappedComponentProps & any> = ({
             <div
               className={`flex flex-column w-100 ${handles.containerFields}`}
             >
-              {!!logo && (
+              {!!logo && logo !== '' && (
                 <div className="mb5">
                   <img
                     src={logo}


### PR DESCRIPTION
#### What does this PR do? 
Persist sku refId with quote items when creating the quote
Hide Logo in quote details page when there is no logo in configurations

#### How to test it? 
Create a quote and navigate to quote details page then you see refId visible in quote items table

[Workspace](https://clouda--ecowaterb2b.myvtex.com/)

